### PR TITLE
Handle the case in which the app is in the background when the notifi…

### DIFF
--- a/src/ios/AppDelegate+APPLocalNotificationAction.m
+++ b/src/ios/AppDelegate+APPLocalNotificationAction.m
@@ -34,4 +34,10 @@
     completionHandler();   
 }  
 
+- (void) application:(UIApplication *)application didReceiveLocalNotification:(nonnull UILocalNotification *)notification
+{
+    NSLog(@"Received local notification %@ while in the foreground, reposting", notification);
+    [[NSNotificationCenter defaultCenter] postNotificationName:CDVLocalNotification object:notification];
+}
+
  @end


### PR DESCRIPTION
…cation is swiped

As we can see from the logs, if the application is in the background when the
notification is clicked, it is not re-launched but simply brought to the
foreground.

If the notification is "clicked" by choosing one of the custom options, the
existing `handleActionWithIdentifier` methods are called. But if the
notification is simply swiped, then `didFinishLaunchingWithOptions` is not
called, since the app is not launched. Instead, the app is first brought to
the foreground and then `didReceiveLocalNotification` is called.

```
2016-12-09 22:33:58.883 emission[52483:346380] About to dispatch {"id":737678,"title":"Trip just ended","actions":[{"destructive":false,"activationMode":"foreground","title":"Mute","icon":"res://ic_moreoptions","identifier":"MUTE","authenticationRequired":false},{"destructive":false,"activationMode":"foreground","title":"Yes","icon":"res://ic_signin","identifier":"REPORT","authenticationRequired":false}],"category":"REPORT_INCIDENT","text":"Incident to report?"}
2016-12-09 22:33:59.004 emission[52483:346380] Application went to the background
2016-12-09 22:33:59.004 emission[52483:346380] DEBUG: Application went to the background
2016-12-09 22:34:01.541 emission[52483:346380] Application will enter the foreground
2016-12-09 22:34:01.541 emission[52483:346380] DEBUG: Application will enter the foreground
2016-12-09 22:34:01.641 emission[52483:346380] UILocalNotification: could not calculate next fire date - previous = 2016-12-10 06:33:59 +0000 : next = 2016-12-10 06:33:59 +0000 : repeatInterval = 2
2016-12-09 22:34:01.641 emission[52483:346380] Received local notification <UIConcreteLocalNotification: 0x7ffe4a90f060>{fire date = Friday, December 9, 2016 at 10:33:59 PM Pacific Standard Time, time zone = America/Los_Angeles (PST) offset -28800, repeat interval = NSCalendarUnitEra, repeat count = UILocalNotificationInfiniteRepeatCount, next fire date = (null), user info = {
    actions =     (
                {
            activationMode = foreground;
            authenticationRequired = 0;
            destructive = 0;
            icon = "res://ic_moreoptions";
            identifier = MUTE;
            title = Mute;
        },
                {
            activationMode = foreground;
            authenticationRequired = 0;
            destructive = 0;
            icon = "res://ic_signin";
            identifier = REPORT;
            title = Yes;
        }
    );
    at = 1481351639;
    badge = 0;
    category = "REPORT_INCIDENT";
    id = 737678;
    sound = "res://platform_default";
    text = "Incident to report?";
    title = "Trip just ended";
}} while in the foreground, reposting
```

We simply catch that and repost it. This is then listened to by this listener,

```
- (void) pluginInitialize
{
....
    [center addObserver:self
               selector:@selector(didReceiveLocalNotification:)
                   name:CDVLocalNotification
                 object:nil];
}
```
which then calls the plugin's `didReceiveLocalNotification` which does all the
event re-posting

Testing done:
- without this change, notifications are not received
- with this change, notifications are received