### PR TITLE
Get `scheduleLocalNotification` to work again for iOS10

### DIFF
--- a/src/ios/UILocalNotification+APPLocalNotification.m
+++ b/src/ios/UILocalNotification+APPLocalNotification.m
@@ -62,7 +62,9 @@ NSInteger const APPLocalNotificationTypeTriggered = 2;
     self.timeZone = [NSTimeZone defaultTimeZone];
     self.applicationIconBadgeNumber = options.badgeNumber;
     self.category = options.category;
+    if (NSCalendarUnitEra != options.repeatInterval) {
     self.repeatInterval = options.repeatInterval;
+    }
     self.alertBody = options.alertBody;
     self.soundName = options.soundName;
 


### PR DESCRIPTION
Apparently, iOS10 has a different expectation for how the
repeat interval should be. Let's set it only if it is really set by the user.
This is a manual port of
https://github.com/EddyVerbruggen/cordova-plugin-local-notifications/commit/5dad35f90e4d9bafc5465f085b2be85398638410