### PR TITLE
Accept the scope parameter to unregister

### DIFF
--- a/www/local-notification.js
+++ b/www/local-notification.js
@@ -365,6 +365,6 @@ exports.on = function (event, callback, scope) {
  * @param {Function} callback
  *      The function to be exec as callback
  */
-exports.un = function (event, callback) {
+exports.un = function (event, callback, scope) {
     this.core.un(event, callback, scope);
 };


### PR DESCRIPTION
We need it to pass it in to the native code, even if we don't use it in the
code