### PR TITLE
Minor fixes to support the change to API 26

### DIFF
--- a/src/android/notification/ClickActivity.java
+++ b/src/android/notification/ClickActivity.java
@@ -40,6 +40,7 @@ public class ClickActivity extends AbstractClickActivity {
     @Override
     public void onClick(Notification notification) {
         launchApp();
+        finish();
     }
 
     /**


### PR DESCRIPTION
In particular:
- change the way in which the notification is built so that it is visible on O+
 consistent with https://github.com/phonegap/phonegap-plugin-push/issues/1949 and
 https://github.com/e-mission/e-mission-docs/issues/325#issuecomment-471849533

- explicitly call finish() when the app is launched so that the no-UI `ClickActivity` can be terminated
https://github.com/e-mission/e-mission-docs/issues/325#issuecomment-474211200

Testing done:
- took a trip
- clicked on the trip end notification
- saw the mode + purpose menu